### PR TITLE
Give centrifuges their own fluidbox tables

### DIFF
--- a/prototypes/override/entity.lua
+++ b/prototypes/override/entity.lua
@@ -34,7 +34,7 @@ for _, machine in pairs(data.raw["assembling-machine"]) do
 	if machine.crafting_categories and not machine.fluid_boxes then
 		for _, category in pairs(machine.crafting_categories) do
 			if category == "centrifuging" then
-				machine.fluid_boxes = fluid_boxes
+				machine.fluid_boxes = table.deepcopy(fluid_boxes)
 				machine.fluid_boxes_off_when_no_fluid_recipe = true
 				break
 			end


### PR DESCRIPTION
https://mods.factorio.com/mod/advanced-centrifuge/discussion/67819160140cb535981f1b84
https://github.com/Quezler/glutenfree/commit/8fc8c18cbd6811751d13326552c3e0abddb96adc

Had to do some compatibility work and notice that if i updated just the offset inside `position` i would get an "1.5" error mentioning the connector is outside the assembling machine because you're giving them all references to the same table, this change gives them their own copy of your fluidbox preset since modders don't expect this when doing compatibility work.