### PR TITLE
Add oxygen property to Cerys when oxygen is enabled(For compatibility with Muluna)

### DIFF
--- a/prototypes/planet/planet.lua
+++ b/prototypes/planet/planet.lua
@@ -58,6 +58,11 @@ PlanetsLib:extend({
 	},
 })
 
+-- If oxygen property is enabled, oxygen for Cerys is set to 0%, in line with Muluna's convention for planets intended to ban burner items.
+if data.raw["surface-property"]["oxygen"] then
+	data.raw["planet"]["cerys"].surface_properties["oxygen"] = 0
+end
+
 data:extend({
 	{
 		type = "space-connection",


### PR DESCRIPTION
In Muluna, vanilla burner entities have their surface condition changed to require at least 1% oxygen instead of looking at pressure. When Muluna and Cerys are loaded simultaneously, this causes the unintended effect of burner entities working on Cerys. Setting Cerys' oxygen value to 0% when oxygen is enabled, as done for Muluna and space platforms, will fix this issue.