### PR TITLE
MOX reactor is no longer gated behind Aquilo

### DIFF
--- a/prototypes/override-final/technology.lua
+++ b/prototypes/override-final/technology.lua
@@ -271,6 +271,10 @@ data:extend({
 				type = "unlock-recipe",
 				recipe = "cerys-mixed-oxide-reactor",
 			},
+			{
+				type = "unlock-recipe",
+				recipe = "lithium-plate",
+			},
 		},
 		prerequisites = {
 			"cerys-plutonium-enhanced-fuel-reprocessing",


### PR DESCRIPTION
MOX reactor requires lithium plates to build, but lithium plates can only be unlocked by visiting Aquilo.

This PR makes it so that lithium plates are unlocked by MOX reactor tech, so the player can now build a MOX reactor pre-Aquilo. All other uses of lithium plates are still Aquilo gated, so this doesn't change vanilla progression.