### PR TITLE
Fusion-related prototype surface condition changes to increase compatibility with Muluna

### DIFF
--- a/prototypes/override-final/entity.lua
+++ b/prototypes/override-final/entity.lua
@@ -189,6 +189,13 @@ local gravity_condition = {
 	min = 0.2,
 }
 
+if data.raw.planet.muluna then
+	gravity_condition = {
+		property = "gravity",
+		min = 0.1,
+	}
+end
+
 for _, entity in pairs(data.raw["cargo-landing-pad"] or {}) do
 	PlanetsLib.relax_surface_conditions(entity, gravity_condition)
 end

--- a/prototypes/override-final/entity.lua
+++ b/prototypes/override-final/entity.lua
@@ -133,12 +133,15 @@ for name, entity in pairs(data.raw["accumulator"]) do
 		PlanetsLib.restrict_surface_conditions(entity, magnetic_field_restriction)
 	end
 end
-for _, entity in pairs(data.raw["fusion-reactor"]) do
-	PlanetsLib.restrict_surface_conditions(entity, magnetic_field_restriction)
-end
-for _, entity in pairs(data.raw["fusion-generator"]) do
-	PlanetsLib.restrict_surface_conditions(entity, magnetic_field_restriction)
-end
+-- for _, entity in pairs(data.raw["fusion-reactor"]) do
+-- 	PlanetsLib.restrict_surface_conditions(entity, magnetic_field_restriction)
+-- end
+-- for _, entity in pairs(data.raw["fusion-generator"]) do
+-- 	PlanetsLib.restrict_surface_conditions(entity, magnetic_field_restriction)
+-- end
+
+PlanetsLib.restrict_surface_conditions(data.raw["fusion-reactor"]["fusion-reactor"], magnetic_field_restriction)
+PlanetsLib.restrict_surface_conditions(data.raw["fusion-generator"]["fusion-generator"], magnetic_field_restriction)
 
 for _, entity in pairs(data.raw["burner-generator"]) do
 	PlanetsLib.restrict_surface_conditions(entity, magnetic_field_restriction)

--- a/prototypes/override-final/entity.lua
+++ b/prototypes/override-final/entity.lua
@@ -189,13 +189,6 @@ local gravity_condition = {
 	min = 0.2,
 }
 
-if data.raw.planet.muluna then
-	gravity_condition = {
-		property = "gravity",
-		min = 0.1,
-	}
-end
-
 for _, entity in pairs(data.raw["cargo-landing-pad"] or {}) do
 	PlanetsLib.relax_surface_conditions(entity, gravity_condition)
 end


### PR DESCRIPTION
This PR makes one change to make Cerys more compatible with Muluna.

1. Surface condition changes to fusion-related prototypes are changed so they only apply to vanilla fusion prototypes. This is to fix a compatibility issue with an entity I'm working on for Muluna named the "Advanced steam turbine," which is internally a fusion generator prototype, but represents a conventional steam turbine with fluid recycling capabilities.

There's an additional change in this PR that I've rolled back due to it not working during testing, which was to adjust gravity-related surface conditions so that cars once again work on Muluna. This change is not as important, but it would be nice if it existed.