### PR TITLE
Update zh-CN locale

### DIFF
--- a/locale/zh-CN/Cerys-Moon-of-Fulgora.cfg
+++ b/locale/zh-CN/Cerys-Moon-of-Fulgora.cfg
@@ -1,19 +1,20 @@
 [mod-name]
-Cerys-Moon-of-Fulgora=○🌐雪璃星
+Cerys-Moon-of-Fulgora=雪璃星
 
 [space-location-name]
 cerys=雪璃星
 
 [space-location-description]
-cerys=雪璃星（Cerys）：一颗没有大气层的神秘卫星，地表被厚厚甲烷冰层所覆盖。在雷神星的磁场影响下，温和的太阳风吹拂着星球表面。在那冰层之下，似乎冻结着许多过去文明遗留的技术，而你或许可以将其修复。雪璃星上的建筑会随时间向地壳散失热量。投放货舱需要特殊技术。
+cerys=雪璃星（Cerys）：一颗没有大气层的雷神星卫星，地表被厚厚的甲烷冰层所覆盖。冰层下埋藏着许多远古废墟，或许，可以将它们修复。雪璃星上的建筑会随时间向地壳散失热量。投放货舱需要特殊科技（建设机器人除外）。
 
 [tips-and-tricks-item-name]
 cerys-briefing=雪璃星导览
 cerys-plutonium-generation=钚生产
 
 [tips-and-tricks-item-description]
-cerys-briefing=雪璃星（Cerys）[planet=cerys]是雷神星的卫星，表面没有大气。\n太阳风被[planet=fulgora]的强磁场影响发生偏转，会影响货舱的降落，需要研究科技[technology=cerys-cargo-drops]才能成功投放货舱。其表面被多层[item=methane-ice]覆盖，到处散布着远古机器残骸。大部分机器都可以重新启用，继续工作。[entity=cerys-fulgoran-radiative-tower]可以加热方形范围内的区域。除了甲烷冰以外，你还可以发现[entity=cerys-nuclear-scrap]，[entity=cerys-ruin-medium]，[entity=cerys-nitrogen-rich-minerals]和[entity=lithium-brine]。\n由于供热相关的物流限制，要在这颗卫星上长期维持一个稳定基地并不容易。
-cerys-plutonium-generation=[item=plutonium-239]有概率在[entity=cerys-solar-wind-particle]撞击[item=uranium-238]时嬗变而生成。\n\n以下是值得注意的机制：\n\n• 每个[item=uranium-238]因撞击而嬗变的概率是独立的，容器内的[item=uranium-238]越多，嬗变为[item=plutonium-239]的概率越高。\n\n• [entity=cerys-solar-wind-particle]几乎停止时会蒸发。\n\n• 传送带上的[item=uranium-238]嬗变概率为在容器内时的二十五倍。\n\n• 钚嬗变的概率与[entity=cerys-solar-wind-particle]的速度无关。\n\n• 即使容器已满，[item=uranium-238]也有可能发生嬗变，此时会有一堆叠的[item=uranium-238]被删除。\n\n• [entity=cerys-solar-wind-particle]与单个容器或传送带重复碰撞时不会让其嬗变；需要与其他容器或传送带碰撞后，原始容器或传送带才能再次被考虑进行嬗变。\n\n• 出于性能原因，[entity=cerys-solar-wind-particle]会在雪璃星表面无人观看时减慢模拟速度，但是每次碰撞的嬗变概率增加，所以[item=plutonium-239]的生产速率保持不变。
+cerys-briefing=[planet=cerys]（Cerys），[planet=fulgora]的卫星，表面没有大气。\n太阳风受[planet=fulgora]的强磁场影响发生偏转，会影响货舱的降落，需要研究[technology=planetslib-cerys-cargo-drops]才能成功投放货舱。\n雪璃星的表面被多层[item=methane-ice]覆盖，到处散布着远古机器残骸。大部分机器都可以重新启用，继续工作；其中，[entity=cerys-fulgoran-radiative-tower]可以加热方形范围内的区域。\n除了甲烷冰以外，你还能找到[entity=cerys-nuclear-scrap]，[entity=cerys-ruin-medium]，[entity=cerys-nitrogen-rich-minerals]和[entity=lithium-brine]。\n由于供热相关的物流限制，要在这颗卫星上长期维持一个稳定基地并不容易。
+
+cerys-plutonium-generation=[item=plutonium-239]有概率在[entity=cerys-solar-wind-particle]撞击[item=uranium-238]时嬗变生成。以下是值得注意的机制：\n\n• 传送带上的[item=uranium-238]嬗变概率为在容器内的30倍。\n\n• [item=plutonium-239]生成的速率与[item=uranium-238]的量成正比。将铀分散到多个容器或传送带上对速率没有影响。\n\n• [entity=cerys-solar-wind-particle]几乎停止时会蒸发。\n\n• 钚嬗变的概率与[entity=cerys-solar-wind-particle]的速度无关。\n\n• 即使容器已满，[item=uranium-238]也有可能发生嬗变，此时会有一堆叠的铀被删除。\n\n• [entity=cerys-solar-wind-particle]与单个容器或传送带重复碰撞时不会引发嬗变；直到它与其他容器或传送带发生碰撞之后，原本的容器或传送带才可再次由其嬗变。\n\n• 幽灵带电粒子会将其他实体视作已充满电。\n\n• 出于性能原因，[entity=cerys-solar-wind-particle]会在雪璃星表面无人观看时减慢模拟速度，但是每次碰撞的嬗变概率会增加，所以[item=plutonium-239]的生产速率保持不变。
 
 [entity-name]
 vent-stack=排气塔
@@ -22,8 +23,8 @@ cerys-nuclear-scrap=核废料
 methane-ice=甲烷冰
 cerys-nitrogen-rich-minerals=富氮矿石
 planetary-asteroid=__1__（近轨）
-cerys-lab=雪璃实验室
-cerys-lab-dummy=占位雪璃实验室
+cerys-lab=雪璃研究中心
+cerys-lab-dummy=占位雪璃研究中心
 cerys-solar-wind-particle=太阳风粒子
 cerys-charging-rod=磁场导引塔
 cerys-ruin-small=小型雪璃废墟
@@ -70,40 +71,40 @@ cerys-solar-ghost-maker=幽灵粒子制造机
 cerys-solar-wind-particle-ghost=幽灵带电粒子
 
 [entity-description]
-cerys-fulgoran-radiative-tower=通过红外辐射加热周围16格范围内的的区域与建筑。运行时消耗固体燃料。
-cerys-fulgoran-radiative-tower-contracted-container=通过红外辐射加热周围16格范围内的的区域与建筑。运行时消耗固体燃料。
-cerys-fulgoran-radiative-tower-contracted-reactor=通过红外辐射加热附近的地面和实体。消耗固体燃料。最大范围：16格。
+cerys-fulgoran-radiative-tower=通过红外辐射加热周围地格与实体。运行时消耗固体燃料。
+cerys-fulgoran-radiative-tower-contracted-container=通过红外辐射加热周围地格与实体。运行时消耗固体燃料。
+cerys-fulgoran-radiative-tower-contracted-reactor=通过红外辐射加热周围地格与实体。运行时消耗固体燃料。
 cerys-fulgoran-reactor-wreck-cleared=废墟正在等待脚手架的搭建。
 cerys-fulgoran-reactor=一座基本可用的古老裂变反应堆。也许可以想办法屏蔽其危险的辐射。
-cerys-fulgoran-reactor-wreck=雷神星上发现的一座古老的处于危急状态的裂变反应堆。
-cerys-fulgoran-reactor-wreck-scaffolded=雷神星上发现的一座古老的处于危急状态的裂变反应堆。已搭建脚手架。
-cerys-fulgoran-reactor-scaffolded=雷神星上发现的一座古老的处于危急状态的裂变反应堆。已搭建脚手架。
+cerys-fulgoran-reactor-wreck=一座古老的裂变反应堆，但已年久失修，处于极其危险的状态。
+cerys-fulgoran-reactor-wreck-scaffolded=一座古老的裂变反应堆，但已年久失修，处于极其危险的状态。已搭建脚手架。
+cerys-fulgoran-reactor-scaffolded=一座古老的裂变反应堆，但已年久失修，处于极其危险的状态。已搭建脚手架。
 cerys-solar-wind-particle=来自太阳风的带电粒子被雷神星的磁场引导，轰击雪璃星。
-cerys-charging-rod=一件设计古怪的雷神科技装置，像蓄电池一样储存和释放能量，用于扭曲雪璃星上的太阳风行进轨迹。
+cerys-charging-rod=一件设计古怪的雷神科技装置，能像蓄电池一样储存和释放能量，用于扭曲雪璃星上的太阳风行进轨迹。
 cerys-gamma-radiation=威胁生命，可以被流体储罐阻挡。
 cerys-mixed-oxide-reactor=使用混合氧化物燃料棒产生热量，有毗邻加成。
 cerys-neutron-dummy=威胁生命。倾向于向各个方向分散。
-cerys-fulgoran-teleporter=一台勉强可用的远古雷神传送机。可以将玩家传送到雷神星上的随机位置。
+cerys-fulgoran-teleporter=一台勉强可用的远古传送机。
 cerys-fulgoran-cryogenic-plant=一台远古的低温工厂，是解密雪璃星上雷神科技的关键。
-cerys-radiation-proof-inserter=在机器中插入和移除[item=cerys-radioactive-module-decayed]和[item=cerys-radioactive-module-charged]。\n机械臂的过滤器、方向和堆叠大小根据机器的状态自动设置。\n传递电路信号[virtual-signal=signal-deny]将禁用机械臂。
-cerys-solar-ghost-maker=创建[entity=cerys-solar-wind-particle-ghost]。用于测试目的很有用。
-cerys-solar-wind-particle-ghost=用于测试目的很有用。
+cerys-radiation-proof-inserter=能在机器中插入和移除[item=cerys-radioactive-module-decayed]与[item=cerys-radioactive-module-charged]。\n机械臂的筛选器、方向、抓取堆叠根据机器的状态自动设定。\n传递电路信号[virtual-signal=signal-deny]将禁用机械臂。
+cerys-solar-ghost-maker=创建[entity=cerys-solar-wind-particle-ghost]。适合用于测试。
+cerys-solar-wind-particle-ghost=适合用于测试。
 
 [item-name]
 cerys-nuclear-scrap=核废料
 methane-ice=甲烷冰
 cerys-nitrogen-rich-minerals=富氮矿石
-cerysian-science-pack=雪璃科技包（青瓶）
+cerysian-science-pack=逆向科技包（青瓶）
 cerys-discover-fulgoran-cryogenics=发现雷神低温技术
-mixed-oxide-fuel-cell=混合氧化燃料电池
-depleted-mixed-oxide-fuel-cell=耗尽的混合氧化燃料电池
+mixed-oxide-fuel-cell=混合氧化物燃料棒
+depleted-mixed-oxide-fuel-cell=枯竭混合氧化物燃料棒
 plutonium-rounds-magazine=钚弹匣
 plutonium-238=钚-238
 plutonium-239=钚-239
 plutonium-fuel=钚燃料
 ancient-structure-repair-part=远古机器修复组件
 cerys-fulgoran-reactor-scaffold=雷神反应堆脚手架
-mixed-oxide-reactor-equipment=便携式混合氧化反应堆
+mixed-oxide-reactor-equipment=混合氧化物反应堆模块
 cerys-fulgoran-reactor=雷神反应堆
 cerys-fulgoran-cryogenic-plant=雷神低温工厂
 cerys-fulgoran-radiative-tower=雷神热辐塔
@@ -114,60 +115,61 @@ cerys-mixed-oxide-reactor=混合氧化物反应堆
 cerys-neutron-bomb=中子弹
 cerys-hydrogen-bomb=氢弹
 cerys-radiative-heater=辐射加热器
-cerys-overclock-module=超频模块
-cerys-radioactive-module-charged=放射性模块（已充电）
-cerys-radioactive-module-decayed=放射性模块（衰减）
-kr-plutonium-rifle-magazine=钚弹夹步枪弹药
-kr-plutonium-anti-materiel-rifle-magazine=钚弹夹反器材步枪弹药
+cerys-overclock-module=超频插件
+cerys-radioactive-module-charged=放射性插件（已充电）
+cerys-radioactive-module-decayed=放射性插件（已衰变）
+kr-plutonium-rifle-magazine=钚步枪弹匣
+kr-plutonium-anti-materiel-rifle-magazine=钚反器材步枪弹匣
+kr-cerysian-research-data=逆向研究数据
 cerys-solar-wind-particle-ghost=幽灵带电粒子
 
 [item-description]
-cerysian-science-pack=对雪璃星上的科技进行逆向工程所需的科技包。
-mixed-oxide-fuel-cell=包含铀和钚的裂变同位素的燃料棒。
-plutonium-238=钚的放射性同位素。是一种宝贵的便携能源。
-plutonium-239=钚的裂变同位素。用于混合氧化物燃料棒中。似乎是以非常规方式制造而成的。
-cerys-fulgoran-reactor-scaffold=可放置在雷神反应堆上以开始施工。需要精确对齐，反应堆上空有小行星时无法放置。
+mixed-oxide-fuel-cell=由铀与钚的易裂变同位素制成。
+plutonium-238=钚的放射性同位素。是宝贵的便携式能源。
+plutonium-239=钚的易裂变同位素。似乎是以非常规方式制造而成的。
+cerys-fulgoran-reactor-scaffold=可放置在雷神反应堆上以开始修复，需要精确对齐，有星岩阻挡时无法放置。在所修复反应堆上超级强制放置（非虚影）高品质的脚手架，可提高反应堆的品质。
 cerys-hydrogen-bomb=发射后请及时远离。
-cerys-discover-fulgoran-cryogenics=代表一种特殊配方，用于解锁 [technology=cerys-fulgoran-cryogenics]。
-cerys-radioactive-module-charged=一种Tier 4生产力模块，会随时间衰减为Tier 2.5等效物，但可以用钚-239在离心机中重新充电。\n可由[item=cerys-radiation-proof-inserter]插入机器。
-cerys-radioactive-module-decayed=[item=cerys-radioactive-module-charged]的衰减形态，强度减半。可在离心机中重新充电。\n可由[item=cerys-radiation-proof-inserter]从机器中取出。
-cerys-overclock-module=一个Tier 4模块，具有两个[item=speed-module-3]的效果。但是，它会抑制生产力奖励并产生污染。
+cerys-discover-fulgoran-cryogenics=代表一种特殊配方，用于解锁[technology=cerys-fulgoran-cryogenics]。
+cerys-radioactive-module-charged=一种4级产能插件，会随时间衰变为2.5级等价物，但可用[item=plutonium-239]在离心机内充电。\n可由[item=cerys-radiation-proof-inserter]插入机器。
+cerys-radioactive-module-decayed=衰变后的[item=cerys-radioactive-module-charged]，强度减半，在离心机中充电后才会恢复原本功能。\n可由[item=cerys-radiation-proof-inserter]从机器中取出。
+cerys-overclock-module=一种4级插件，具有两个[item=speed-module-3]的效果。但是，它会抑制额外产能。
 
 [recipe-name]
 cerys-lubricant-synthesis=润滑油合成
 methane-ice-dissociation=甲烷冰解离
-cerys-nitrogen-rich-mineral-processing=富氮矿石处理
+cerys-nitrogen-rich-mineral-processing=矿物浸出
 cerys-nuclear-scrap-recycling=核废料回收
-nitric-treatment-of-uranium-cell=铀燃料棒硝酸处理
-nitric-treatment-of-mixed-oxide-cell=混合氧化物燃料棒硝酸处理
-sulfuric-treatment-of-uranium-cell=铀燃料棒硫酸处理
-mixed-oxide-cell-reprocessing=混合氧化物燃料棒再处理
-mixed-oxide-waste-centrifuging=混合氧化物废料离心处理
+nitric-treatment-of-uranium-cell=铀燃料棒后处理
+nitric-treatment-of-mixed-oxide-cell=混合氧化物燃料棒后处理
+sulfuric-treatment-of-uranium-cell=铀燃料棒后处理
+mixed-oxide-cell-reprocessing=混合氧化物燃料棒后处理
+mixed-oxide-waste-centrifuging=混合氧化物废料离心
 cerys-repair-cryogenic-plant=修复雷神低温工厂
 cerys-repair-crusher=修复雷神破碎机
 ancient-structure-repair-part=远古机器修复组件
-cerys-repair-nuclear-reactor=修复雷神核反应堆
-cerys-excavate-nuclear-reactor=挖掘雷神核反应堆
-cerys-processing-units-from-nitric-acid=用硝酸生产处理器
+cerys-repair-nuclear-reactor=修复雷神裂变反应堆
+cerys-excavate-nuclear-reactor=发掘雷神裂变反应堆
+cerys-processing-units-from-nitric-acid=硝酸制处理器
 cerys-upgrade-fulgoran-cryogenic-plant-quality=升级雷神低温工厂品质
 cerys-upgrade-fulgoran-crusher-quality=升级雷神破碎机品质
 cerys-radiative-heater=辐射加热器
 maraxsis-holmium-recrystalization=钬重结晶
 cerys-nitric-acid=硝酸
-cerys-utility-science-pack=雷神低温技术实用科技包
-cerys-speed-module-3-from-nitric-acid=从硝酸制造的效率模块 3
-cerys-from-mixed-oxide=__1__（来自混合氧化物）
-cerys-space-science-pack-from-methane-ice=从甲烷冰制造太空科技包
+cerys-utility-science-pack=雷神低温工厂产效能科技卡
+cerys-speed-module-3-from-nitric-acid=硝酸制速度插件 3
+cerys-from-mixed-oxide=混合氧化物制__1__
+cerys-space-science-pack-from-methane-ice=甲烷冰制太空科技包
 cerys-make-solar-wind-ghosts=创建太阳风幽灵
-cerys-radioactive-module-recharging=放射性模块重新充电
-cerys-explosives-from-ammonium-nitrate=硝酸盐氧化法制造炸药
+cerys-radioactive-module-recharging=放射性插件充电
+cerys-explosives-from-ammonium-nitrate=硝酸盐氧化法制炸药
+plutonium-239=钚-239
 
 [recipe-description]
 cerys-lubricant-synthesis=使用锂作为催化剂，雷神低温工厂可以将碳氢化合物凝聚成润滑油。
-cerys-upgrade-fulgoran-cryogenic-plant-quality=完成此配方后，如果其品质高于工厂品质，则工厂将升级到配方品质。
-cerys-upgrade-fulgoran-crusher-quality=升级制造此配方的破碎机的品质一级。需要比破碎机品质高一级的材料。\n\n高品质的破碎机有额外的插件槽位。
+cerys-upgrade-fulgoran-cryogenic-plant-quality=为执行此配方的低温工厂提升一级品质。所用原材料的品质须比低温工厂高一级。
+cerys-upgrade-fulgoran-crusher-quality=为执行此配方的破碎机提升一级品质。所用原材料的品质须比破碎机高一级。
 cerys-nitric-acid=通过电解氨和水制备硝酸。
-cerys-excavate-nuclear-reactor=揭示雷神反应堆废墟。
+cerys-excavate-nuclear-reactor=让雷神反应堆废墟重见天日。
 
 [technology-name]
 moon-discovery-cerys=发现卫星：雪璃星
@@ -175,11 +177,11 @@ cerys-nuclear-scrap-recycling=核废料回收
 cerys-nitrogen-rich-mineral-processing=矿物浸出
 cerys-fulgoran-cryogenics=雷神低温技术
 cerys-electromagnetic-tooling=电磁工具
-cerysian-science-pack=逆向工程科技包
+cerysian-science-pack=逆向科技包（青瓶）
 cerys-gas-venting=气体排放
 cerys-lubricant-synthesis=润滑油合成
 cerys-advanced-structure-repair=高级结构修复
-cerys-mixed-oxide-waste-reprocessing=混合氧化物废料处理
+cerys-mixed-oxide-waste-reprocessing=混合氧化物废料后处理
 cerys-applications-of-radioactivity=放射性应用
 cerys-cargo-drops=雪璃星货舱投放
 cerys-holmium-plate-productivity=钬板增产计划
@@ -188,32 +190,37 @@ cerys-plutonium-weaponry=钚制武器技术
 cerys-radiative-heaters=辐射加热器
 cerys-nice-try-sukaz=干得好！
 cerys-holmium-recrystallization=钬重结晶
-cerys-radioactive-module=放射性模块
-cerys-overclock-module=超频模块
+cerys-radioactive-module=放射性插件
+cerys-overclock-module=超频插件
 cerys-reactor-fuel=混合氧化物反应堆燃料
 cerys-holmium-recrystalization=钬重结晶
 cerys-mixed-oxide-reactors=混合氧化物反应堆
+cerys-legacy-reactor-fuel-productivity=旧版反应堆燃料增产计划
+cerys-plutonium-productivity=钚产能
+cerys-braking-force=制动技术
 
 [technology-description]
-moon-discovery-cerys=雪璃星（Cerys）:一颗没有大气层的神秘卫星，地表被厚厚甲烷冰层所覆盖。在雷神星的磁场影响下，温和的太阳风吹拂过星球。冰层下埋藏着许多过去文明遗留的技术，包括一个巨大的核反应堆。或许，可以将它修复…
-cerys-nuclear-scrap-recycling=允许在雪璃星上将核废料手动或通过机器回收成有用的材料。
-cerys-nitrogen-rich-mineral-processing=允许通过硫酸进行矿物浸出，释放硝酸化合物和铁矿石。
+moon-discovery-cerys=雪璃星（Cerys）：一颗没有大气层的雷神星卫星，地表被厚厚的甲烷冰层所覆盖。在雷神星的磁场影响下，温和的太阳风吹拂过星球。冰层下埋藏着许多远古废墟，包括一个巨大的反应堆，或许，可以将它们修复。\n\n前往雷神星并非必须前提条件。在雪璃星上投放货舱需要特殊科技（建设机器人除外）。雪璃星上的建筑会随时间向地壳散失热量。
+cerys-nuclear-scrap-recycling=雪璃星上的雷神核工业废墟可以手动或通过机器进行回收。
+cerys-nitrogen-rich-mineral-processing=用硫酸浸出富氮矿石，释放硝酸化合物和铁矿。
 cerys-fulgoran-cryogenics=在[entity=cerys-fulgoran-cryogenic-plant]中解锁一系列功能。
-cerys-electromagnetic-tooling=用于储存能量和实验电磁场的设备。
-cerysian-science-pack=深入了解雪璃星上雷神科技的更多见解。
-cerys-gas-venting=轻松排放气体和（在有大气层表面）销毁液体的方法。
+; cerys-fulgoran-cryogenics=Researched directly in the Fulgoran cryogenic plant (the technology must be selected for research.)
+cerys-electromagnetic-tooling=用于储存能量和进行电磁场实验的设备。
+cerysian-science-pack=深入了解雪璃星上的雷神科技，获得更多见解。
+cerys-gas-venting=销毁气体和（在有一定气压的表面上）销毁液体的简单方式。
 cerys-lubricant-synthesis=允许使用锂催化剂将碳氢化合物合成为润滑油。
-cerys-advanced-structure-repair=允许制作脚手架以准备进行雷神核反应堆修复工作。
-cerys-mixed-oxide-waste-reprocessing=已耗尽的混合氧化物燃料棒可以再处理为更多的钚-239，以及其他高度放射性的同位素。
-cerys-cargo-drops=货舱着陆过程中，可以抵御太阳风和雷神星磁场的干扰。允许货舱在雪璃星更安全地着陆，使之在雪璃星不再仅限于运载玩家和建筑机器人。
+cerys-advanced-structure-repair=允许对雷神机器进行高级修复和升级，其中包括修复雷神核反应堆所需安装的脚手架。
+cerys-mixed-oxide-waste-reprocessing=枯竭的混合氧化物燃料棒可后处理为更多钚-239，还能产出另一种具有高度放射性的同位素。
+cerys-cargo-drops=允许货舱在不受磁层大气干扰的情况下，于雪璃星着陆。
 cerys-plutonium-weaponry=能够摧毁大片区域的钚武器技术。
-cerys-applications-of-radioactivity=研究利用钚同位素的特殊性质。
-cerys-radiative-heaters=允许建造热辐塔，使用红外辐射加热周围的区域。同时允许在雪璃星上开采雷神星的热辐塔。
-cerys-reactor-fuel=包含多种化学元素的雷神反应堆燃料棒。
-cerys-radioactive-module=一种Tier 4生产力模块变体，会衰减为Tier 2.5等效物。可以使用[item=cerys-radiation-proof-inserter]插入机器中。
-cerys-overclock-module=一种Tier 4速度模块变体，具有[item=speed-module-3]双倍效果。但是，它会抑制生产力奖励并产生污染。
+cerys-applications-of-radioactivity=研究利用钚的放射性同位素。
+cerys-radiative-heaters=允许建造辐射加热器，同时允许开采雪璃星上的热辐塔。
+cerys-reactor-fuel=使用多种化学元素制成的裂变反应堆燃料棒。
+cerys-radioactive-module=一种4级产能插件，会衰变为2.5级等价物。可由[item=cerys-radiation-proof-inserter]插入机器。
+cerys-overclock-module=一种4级速度插件，效果是[item=speed-module-3]的两倍。但是，它会抑制额外产能。
 cerys-holmium-recrystalization=钬矿的高级处理。
-cerys-mixed-oxide-reactors=升级的裂变反应堆（用于异星使用）。
+cerys-mixed-oxide-reactors=可在其他星球使用的升级版裂变反应堆。
+cerys-legacy-reactor-fuel-productivity=雪璃星v4.0中，燃料棒配方不再包含产能插件。为避免破坏已有的太空平台，旧版的存档会解锁这项秘密科技。可在模组设置中禁用。
 
 [fuel-category-name]
 chemical-or-radiative=化学燃料
@@ -225,30 +232,30 @@ nitric-acid=硝酸
 mixed-oxide-waste-solution=混合氧化物废料溶液
 
 [tile-name]
-cerys-ash-cracks=雪璃星灰裂缝
-cerys-ash-cracks-frozen=雪璃星灰裂缝（冻）
-cerys-ash-cracks-frozen-from-dry-ice=雪璃星灰裂缝（冻）
-cerys-ash-dark=雪璃星灰暗区
-cerys-ash-dark-frozen=雪璃星灰暗区（冻）
-cerys-ash-dark-frozen-from-dry-ice=雪璃星灰暗区（冻）
-cerys-ash-flats=雪璃星灰平原
-cerys-ash-flats-frozen=雪璃星灰平原（冻）
-cerys-ash-flats-frozen-from-dry-ice=雪璃星灰平原（冻）
-cerys-ash-light=雪璃星灰光区
-cerys-ash-light-frozen=雪璃星灰光区（冻）
-cerys-ash-light-frozen-from-dry-ice=雪璃星灰光区（冻）
+cerys-ash-cracks=雪璃星纹岩
+cerys-ash-cracks-frozen=雪璃星纹岩（冻结）
+cerys-ash-cracks-frozen-from-dry-ice=雪璃星纹岩（冻结）
+cerys-ash-dark=雪璃星硬岩
+cerys-ash-dark-frozen=雪璃星硬岩（冻结）
+cerys-ash-dark-frozen-from-dry-ice=雪璃星硬岩（冻结）
+cerys-ash-flats=雪璃星灰烬（平）
+cerys-ash-flats-frozen=雪璃星灰烬（平）（冻结）
+cerys-ash-flats-frozen-from-dry-ice=雪璃星灰烬（平）（冻结）
+cerys-ash-light=雪璃星灰烬（浅色）
+cerys-ash-light-frozen=雪璃星灰烬（浅色）（冻结）
+cerys-ash-light-frozen-from-dry-ice=雪璃星灰烬（浅色）（冻结）
 cerys-pumice-stones=雪璃星浮石
-cerys-pumice-stones-frozen=雪璃星浮石（冻）
-cerys-pumice-stones-frozen-from-dry-ice=雪璃星浮石（冻）
+cerys-pumice-stones-frozen=雪璃星浮石（冻结）
+cerys-pumice-stones-frozen-from-dry-ice=雪璃星浮石（冻结）
 cerys-water-puddles=水洼
 cerys-water-puddles-freezing=水洼
 cerys-ice-on-water=水面冰层
-cerys-ice-on-water-melting=水面冰层融化
+cerys-ice-on-water-melting=水面冰层
 cerys-dry-ice-on-water=干燥冰
 cerys-dry-ice-on-water-melting=干燥冰
 cerys-dry-ice-on-land=干燥冰
 cerys-dry-ice-on-land-melting=干燥冰
-cerys-concrete=雪璃星混凝土
+cerys-concrete=标准混凝土
 cerys-empty-space=虚空
 cerys-empty-space-2=虚空
 cerys-empty-space-3=虚空
@@ -261,9 +268,9 @@ cerys-methane-iceberg-medium=中型甲烷冰山
 cerys-methane-iceberg-small=小型甲烷冰山
 cerys-methane-iceberg-tiny=微型甲烷冰山
 cerys-ice-decal-white=雪璃星白色冰霜
-cerys-crater-large=雪璃星大型陨石坑
-cerys-crater-small=雪璃星小型陨石坑
-cerys-ruin-tiny=微型雪璃星废墟
+cerys-crater-large=雪璃星大陨击坑
+cerys-crater-small=雪璃星小陨击坑
+cerys-ruin-tiny=微型雪璃废墟
 
 [surface-property-name]
 cerys-ambient-radiation=环境辐射
@@ -277,70 +284,74 @@ charging-rod-negative-polarity-label=正极
 charging-rod-positive-polarity-label=负极
 charging-rod-polarity-circuit-control-label=使用信号网络控制极性
 charging-rod-polarity-circuit-control-tooltip=信号网络中指定信号的值为0时，电极的极性为正。
-flaring-recipe-suffix=焚烧
-venting-recipe-suffix=排气
+flaring-recipe-suffix=（焚烧）
+venting-recipe-suffix=（排放）
 repair-remaining-description=__1__ [__2__/__3__]
 kofi-toast=核爆掠天而过，一缕火光写下：ko-fi.com/thesixthroc
 teleporter-title=远古雷神传送机
 teleporter-button-text=传送到雷神星
-teleporter-button-text-confirm=你确定？
-teleporter-button-tooltip=将玩家传送到雷神星上的随机位置。
-teleporter-status-label=准备
-reactor-quality-upgrade-scaffold-quality-too-low=【提示】你需要使用比现有反应堆更高品质的脚手架来升级它。
-nitric-acid-by-ammonia-oxidation=通过氨气氧化制备硝酸
+teleporter-button-text-confirm=你确定吗？
+teleporter-button-tooltip=将玩家传送到雷神星上的随机位置。玩家物品栏中的物品不会被传送。
+teleporter-status-label=就绪
+reactor-quality-upgrade-scaffold-quality-too-low=[低语] 你需要使用品质高于反应堆当前等级的脚手架才能进行升级。
+nitric-acid-by-ammonia-oxidation=氨氧化法制硝酸
 alternative-recipe-from-mixed-oxide=使用__1__的替代配方。
-from-mixed-oxide=来自混合氧化物的__1__
-from-methane-ice=来自甲烷冰的__1__
-space-science-pack-from-methane-ice-technology-description=从[item=methane-ice]生产[item=space-science-pack]的替代方法。
-restores-to-working-order=恢复__1__到工作状态。
+from-mixed-oxide=混合氧化物制__1__
+restores-to-working-order=将__1__恢复到工作状态。
 radiative-tower-range-tooltip-name=最大加热半径
 player-radiative-tower-range-tooltip-name=最大加热范围
 radiative-tower-temperature-loss-rate-tooltip-name=温度损失
 charging-rod-voltage-tooltip-name=最大电压
 completions-needed-tooltip-name=需要完成数
+cooling-tooltip-name=冷却速率
 tooltip-unknown-value=?
 tooltip-by-default=默认：__1__
 metres-tooltip-value=__1__ 米
 kv-tooltip-value=__1__ kV
+cooling-tooltip-value=__1__°C/s
 quality-tooltip-header-decreases-with-higher-qualities=随着品质提高而降低
-charging-rod-performance-warning=[雪璃星]: 检测到400个充电棒。请注意，当玩家在雪璃星上且太阳风在附近时，每个充电棒都可能影响游戏性能。
-mining-radiative-towers=允许在雪璃星上开采雷神热辐塔。
+charging-rod-performance-warning=[雪璃星]：检测到400个磁场导引塔。请注意，玩家身处雪璃星且附近有太阳风时，每个导引塔都会影响游戏性能。
+mining-radiative-towers=允许开采雪璃星上的雷神热辐塔。
 cargo-drops-tech-name=在磁层中炸开一个洞
-cargo-drops-tech-description=从火箭发射井将一枚强大的核弹送入雪璃星轨道，使货舱能够在不受磁层大气干扰的情况下着陆。
+cargo-drops-tech-description=使用火箭发射井向雪璃星轨道发射一颗强大的核弹，以让货舱在不受磁层大气干扰的情况下着陆。
 planetary-asteroid-description=由于磁层大气，对激光免疫。
-neutron-bomb-description=一枚微型核弹，释放中子并在压力不低于 __1__ 时散成云。
+neutron-bomb-description=一枚微型核弹，释放出的中子会在压力不低于__1__时散成云。
+from-methane-ice=甲烷冰制__1__
+space-science-pack-from-methane-ice-technology-description=使用[item=methane-ice]生产[item=space-science-pack]的替代方法。
+kr-cerysian-tech-card=逆向科技卡
 
 [mod-setting-name]
-cerys-prevent-cargo-drops-without-technology=未解锁相关技术时，禁止货舱携带货物在雪璃星投放
-cerys-disable-solar-wind-when-not-looking-at-surface=视线不在雪璃星表面时禁用太阳风
+cerys-prevent-cargo-drops-without-technology=未解锁科技时禁止向雪璃星投放货舱
+cerys-disable-solar-wind-when-not-looking-at-surface=视线不在雪璃星时静滞太阳风
 cerys-solar-wind-performance-mode=太阳风性能模式
-cerys-plutonium-generation-rate-multiplier=钚生成速率倍率
+cerys-plutonium-generation-rate-multiplier=钚生成速率乘数
 cerys-technology-compatibility-mode=科技兼容模式
-cerys-asteroid-chunks-drop-on-belts=近轨小行星将碎块掉落在传送带上
-cerys-solar-wind-spawn-rate-percentage=太阳风生成百分比
-cerys-disable-quality-mechanics=禁用品质机制
-cerys-enforce-vanilla-recycling-recipes=强制使用原版回收配方
-cerys-disable-kofi-toast=禁用首次升天提示
-cerys-dynamic-lighting=雪璃星动态光照
-cerys-infinite-braking-technology=添加无限科技：制动技术
-cerys-sandbox-mode=开局可空投
-cerys-disable-parallax-in-multiplayer=在多人游戏中禁用雷神的视差效果
-cerys-use-fulgora-starmap-graphic=使用雷神星图图形
-cerys-undo-marathon-multiplier=抵消科技价格倍率（马拉松）
-cerys-radiative-heaters-require-cryogenic-science=辐射加热器科技需要低温科学包
-cerys-fusion-reactor-requires-radiative-tower=聚变反应堆科技需要辐射塔科技
+cerys-asteroid-chunks-drop-on-belts=近轨星岩向传送带掉落星块
+cerys-solar-wind-spawn-rate-percentage=太阳风生成速率百分比
+cerys-disable-quality-mechanics=禁用机器品质升级
+cerys-enforce-vanilla-recycling-recipes=阻止特定回收配方覆盖
+cerys-disable-kofi-toast=禁用首次火箭发射提示
+cerys-dynamic-lighting=雪璃星动态光源
+cerys-infinite-braking-technology=添加制动技术无限科技
+cerys-sandbox-mode=沙盒模式
+cerys-disable-parallax-in-multiplayer=在多人游戏中禁用雷神星视差效果
+cerys-use-fulgora-starmap-graphic=使用雷神星星图图像
+cerys-disable-secret-cell-productivity-tech-for-legacy-saves=禁用适用于旧版存档的秘密燃料棒增产计划科技
+cerys-undo-marathon-multiplier=抵消雪璃星科技的花费乘数
+cerys-radiative-heaters-require-cryogenic-science=辐射加热器科技需要低温科技包
+cerys-fusion-reactor-requires-radiative-tower=聚变反应堆需要辐射加热器科技
 
 [mod-setting-description]
-cerys-asteroid-chunks-drop-on-belts=在传送带上掉落碎块默认启用，以便仅使用传送带进行自动化小行星采集。
-cerys-prevent-cargo-drops-without-technology=建筑机器人和玩家不受限制
-cerys-disable-solar-wind-when-not-looking-at-surface=在未聚焦雪璃星表面时禁用太阳风生成或移动，以减少性能消耗。会影响游戏体验。
-cerys-technology-compatibility-mode=雷神低温科技使用了异星工厂2.0中新引进的特性，可能会导致处理配方相关的模组无法正常工作。这个设置将相关科技的完成条件修改为完成物品制作触发器（远古机器修复组件），而不是将配方的产物设置为科技研究进度。
+cerys-asteroid-chunks-drop-on-belts=默认启用星块向传送带掉落，以便仅使用传送带自动化星岩采集。
+cerys-prevent-cargo-drops-without-technology=建设机器人和玩家不受限制。
+cerys-disable-solar-wind-when-not-looking-at-surface=默认情况下，玩家视线不在雪璃星时太阳风的UPS使用会大幅缩减。此设置会在这种情景下完全禁止太阳风的移动，为UPS进行彻底的优化。会影响游戏体验。
+cerys-technology-compatibility-mode=雷神低温技术科技使用了异星工厂2.0新引入的特性，可能会导致处理配方相关的模组无法正常工作。此设置将触发科技修改为合成物品（远古机器修复组件）时触发，而不是在配方完成时触发。
 cerys-solar-wind-spawn-rate-percentage=性能优化选项。会影响游戏体验。
-cerys-disable-quality-mechanics=禁用雪璃星中与品质相关的部分。
-cerys-enforce-vanilla-recycling-recipes=强制使用原版回收配方，确保游戏中的某些回收配方保持原版形式，以便雪璃星可玩。影响：管道、热管、插件效果分享塔、汽轮机、离心机、铁齿轮、铜缆、电路板、高级电路、处理器、混凝土、固体燃料、钢材、铜板、铁板、石砖、塑料棒、钬板。注意：安装 Krastorio 2 时，某些覆盖选项不适用。
-cerys-dynamic-lighting=影响太阳能效率。在雪璃星上启用动态光照。可能会导致旧版本加载存档或低性能设备上的图形问题。
-cerys-infinite-braking-technology=充分利用钚燃料的必要条件。由于 Cerys 是一个独立模组，因此默认禁用。
-cerys-sandbox-mode=移除禁止货舱投放的科技限制。允许在雪璃星上进行自由探索。会影响游戏体验，但是更适合休闲玩家，消耗时间更少。
-cerys-use-fulgora-starmap-graphic=雪璃星背景将使用雷神星图图标，增加与修改雷神外观的模组的兼容性。
-cerys-undo-marathon-multiplier=用于抵消地图设置中的”马拉松”（科技价格倍率）。例如当该值为 3 时，（非无限）雪璃星科技的价格将降低 3 倍。可能存在四舍五入误差。
-cerys-fusion-reactor-requires-radiative-tower=将辐射塔科技设为阿奎洛聚变反应堆的前置科技，使雪璃星成为游戏进程的必经之路。
+cerys-disable-quality-mechanics=兼容性设置。移除升级雷神机器品质的配方。
+cerys-enforce-vanilla-recycling-recipes=确保部分回收配方使用原版形式，以便雪璃星可玩。影响：管道、热管、插件效果分享塔、汽轮机、离心机、铁齿轮、铜缆、电路板、集成电路、处理器、标准混凝土、固体燃料、钢材、石砖、塑料、钬板。注意：安装Krastorio 2时部分覆盖的表现会有差异。
+cerys-dynamic-lighting=启用此设置可能会导致雪璃星v2之前的世界生成及低品质图像出现伪影。会影响太阳能。
+cerys-infinite-braking-technology=是将钚燃料性能发挥到极致的必需品。由于雪璃星是内容独立的模组，默认禁用。
+cerys-sandbox-mode=移除雪璃星货舱投放的科技限制。允许在雪璃星上进行自由探索。会影响游戏体验，但是更适合休闲玩家，消耗时间更少。
+cerys-use-fulgora-starmap-graphic=改动雷神星外观的模组也会改变雪璃星背景的雷神星图像。警告：会导致雪璃星原版的雷神星背景模糊。
+cerys-undo-marathon-multiplier=可用于偏移地图设置中的科技花费乘数（长期作战预设）。例如，该值为3时，雪璃星（非无限）科技的花费会缩减至1/3。可能会出现取整误差。
+cerys-fusion-reactor-requires-radiative-tower=将辐射加热器科技设为玄冥星上聚变反应堆的前置，使得雪璃星成为游戏进程的必经之路。

--- a/locale/zh-CN/mod.cfg
+++ b/locale/zh-CN/mod.cfg
@@ -1,3 +1,3 @@
 [mod-description]
-Cerys-Moon-of-Fulgora=一颗神秘的卫星。被厚冰层掩盖的远古机器似乎可以被修复，其中还有一个恢弘的反应堆，有改变地貌的强大可能……前提是把它修好。\n\n雪璃星被设计成一个完整的星球模组，不影响原版游戏体验。你可以在原版游戏中无缝添加它。
+Cerys-Moon-of-Fulgora=雷神星的神秘卫星。被厚重冰层掩盖的远古废墟似乎可以修复，地表还有一座恢弘的反应堆，有激发出全新可能的潜力……前提是把它修好。\n\n雪璃星是体验完整、经过细致打磨的模组，不会对原版游戏做出任何改动，在已有的存档内可以无缝添加。
 ;; Fulgora's moon of puzzles. Ancient wrecks embedded in thick ice can seemingly be repaired, including a colossal nuclear reactor that could transform the possibilities on the surface... if you can get it working.\n\nCerys is a polished and complete planet mod that does not affect the vanilla game in any way, so is easy to include in existing saves.


### PR DESCRIPTION
Mainly fixes on vanilla terms and updates to fit the latest `en` locale files.

"Plutonium productivity" is translated with conventions for "Mining productivity" and "Scrap recycling productivity" in `zh-CN`.

Would like to ask about whether `cerys-dry-ice-on-water` ("Dry ice") is the real life dry ice, the previous translations on this stays unchanged as "干燥冰"/"ice which is dry".