### PR TITLE
Performance improvements

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -12,3 +12,5 @@ require("scripts.radiative-tower")
 require("scripts.reactor-repair")
 require("scripts.teleporter")
 require("scripts.terrain")
+
+if script.active_mods["gvv"] then require("__gvv__.gvv")() end

--- a/lib.lua
+++ b/lib.lua
@@ -2,8 +2,12 @@ local util = require("util")
 local common = require("common")
 local Public = {}
 
+
+
+
 function Public.get_cerys_surface_stretch_factor(cerys_surface)
-	local height_starts_stretching = common.CERYS_RADIUS * (common.HARD_MODE_ON and 2.4 or 1.6)
+	if not storage.cerys_surface_stretch_factor then
+		local height_starts_stretching = common.CERYS_RADIUS * (common.HARD_MODE_ON and 2.4 or 1.6)
 	local max_stretch_factor = 6
 
 	local stretch_factor = math.min(
@@ -11,7 +15,9 @@ function Public.get_cerys_surface_stretch_factor(cerys_surface)
 		height_starts_stretching / math.min(cerys_surface.map_gen_settings.height / 2, height_starts_stretching)
 	)
 
-	return stretch_factor
+	storage.cerys_surface_stretch_factor = stretch_factor
+	end
+	return storage.cerys_surface_stretch_factor
 end
 
 function Public.cerys_surface_stretch_factor_for_math()
@@ -30,22 +36,27 @@ function Public.get_cerys_semiminor_axis(cerys_surface)
 	return common.CERYS_RADIUS / Public.get_cerys_surface_stretch_factor(cerys_surface)
 end
 
+
+
 function Public.generated_cerys_surface()
 	local surface = game.surfaces["cerys"]
 	if not (surface and surface.valid) then
 		return false
 	end
-
-	local some_chunk_generated = false
+	if storage.surface_some_chunk_generated then return surface end
+	
+	
+	
+	
 
 	for chunk in surface.get_chunks() do
 		if surface.is_chunk_generated(chunk) then
-			some_chunk_generated = true
+			storage.surface_some_chunk_generated = true
 			break
 		end
 	end
 
-	if not some_chunk_generated then
+	if not storage.surface_some_chunk_generated then
 		return false
 	end
 

--- a/scripts/atmosphere.lua
+++ b/scripts/atmosphere.lua
@@ -226,6 +226,16 @@ local function remove_particle_at(i)
 end
 Public.remove_particle_at = remove_particle_at
 
+local function cached_scale_factor(ticks_until_death)
+	local s = storage.cached_scale_factor[ticks_until_death]
+    if s == nil then
+        s = math.sqrt(math.max(0.00001, ticks_until_death / PARTICLE_SHRINK_TIME))
+        storage.cached_scale_factor[ticks_until_death] = s
+    end
+    return s
+
+end
+
 function Public.tick_1_move_solar_wind()
 	local i = 1
 	while i <= #storage.solar_wind_particles do
@@ -236,7 +246,10 @@ function Public.tick_1_move_solar_wind()
 		if r and r.valid then
 			local p = { x = particle.position.x + v.x, y = particle.position.y + v.y }
 			particle.position = p
-			r.target = p
+			if storage.player_looking_at_cerys then
+				r.target = {type = "position", position = p} --Render particle only if players are looking at Cerys. This saves a lot of performance when not looking at Cerys without changing any gameplay mechanics
+			end
+			
 			particle.age = particle.age + 1
 
 			if particle.marked_for_death_tick then
@@ -249,13 +262,13 @@ function Public.tick_1_move_solar_wind()
 					remove_particle_at(i)
 				else
 					if particle.rendering and particle.rendering.valid then
-						local scale_factor = math.max(0.00001, ticks_until_death / PARTICLE_SHRINK_TIME) ^ (1 / 2)
+						local scale_factor = cached_scale_factor(ticks_until_death)
 						particle.rendering.x_scale = scale_factor
 						particle.rendering.y_scale = scale_factor
 					end
 				end
 			end
-
+			
 			i = i + 1
 		else
 			remove_particle_at(i)

--- a/scripts/atmosphere.lua
+++ b/scripts/atmosphere.lua
@@ -246,9 +246,9 @@ function Public.tick_1_move_solar_wind()
 		if r and r.valid then
 			local p = { x = particle.position.x + v.x, y = particle.position.y + v.y }
 			particle.position = p
-			if storage.player_looking_at_cerys then
+			--if storage.player_looking_at_cerys then
 				r.target = {type = "position", position = p} --Render particle only if players are looking at Cerys. This saves a lot of performance when not looking at Cerys without changing any gameplay mechanics
-			end
+			--end
 			
 			particle.age = particle.age + 1
 

--- a/scripts/atmosphere.lua
+++ b/scripts/atmosphere.lua
@@ -107,7 +107,7 @@ function Public.try_spawn_asteroid(surface)
 	end
 end
 
-function Public.spawn_solar_wind_particle(surface)
+function Public.spawn_solar_wind_particle(surface,tick)
 	local d = common.CERYS_RADIUS / lib.get_cerys_surface_stretch_factor(surface)
 
 	local y = math.random(-d - 8, d + 8)
@@ -124,7 +124,8 @@ function Public.spawn_solar_wind_particle(surface)
 
 	table.insert(storage.solar_wind_particles, {
 		rendering = r,
-		age = 0,
+		--age = 0,
+		birth_tick=tick,
 		velocity = Public.initial_solar_wind_velocity(),
 		position = { x = x, y = y },
 		surface_index = surface.index,
@@ -250,7 +251,7 @@ function Public.tick_1_move_solar_wind()
 				r.target = {type = "position", position = p} --Render particle only if players are looking at Cerys. This saves a lot of performance when not looking at Cerys without changing any gameplay mechanics
 			--end
 			
-			particle.age = particle.age + 1
+			--particle.age = particle.age + 1 --Now achieved via tracking the birth tick of new solar wind
 
 			if particle.marked_for_death_tick then
 				local ticks_until_death = PARTICLE_SHRINK_TIME - (game.tick - particle.marked_for_death_tick)
@@ -324,7 +325,7 @@ function Public.tick_5_solar_wind_destroy_check()
 	end
 end
 
-function Public.tick_240_clean_up_cerys_solar_wind_particles(surface)
+function Public.tick_240_clean_up_cerys_solar_wind_particles(surface,tick)
 	local have_cerys = surface and surface.valid
 	local semimajor_axis, semiminor_axis, cerys_surface_index
 	if have_cerys then
@@ -340,7 +341,7 @@ function Public.tick_240_clean_up_cerys_solar_wind_particles(surface)
 		local particle = storage.solar_wind_particles[i]
 
 		local kill = false
-		if particle.age > MAX_AGE then
+		if (particle.birth_tick and (tick > particle.birth_tick + MAX_AGE)) or (particle.age and particle.age > MAX_AGE) then
 			kill = true
 		elseif not have_cerys or particle.surface_index ~= cerys_surface_index then
 		else

--- a/scripts/atmosphere.lua
+++ b/scripts/atmosphere.lua
@@ -241,14 +241,15 @@ function Public.tick_1_move_solar_wind()
 	local i = 1
 	while i <= #storage.solar_wind_particles do
 		local particle = storage.solar_wind_particles[i]
-		local r = particle.rendering
-		local v = particle.velocity
+		--local r = particle.rendering
+		--local v = particle.velocity
 
-		if r and r.valid then
-			local p = { x = particle.position.x + v.x, y = particle.position.y + v.y }
-			particle.position = p
+		if particle.rendering and particle.rendering.valid then
+			--local p = { x = particle.position.x + v.x, y = particle.position.y + v.y }
+			particle.position.x = particle.position.x + particle.velocity.x
+			particle.position.y = particle.position.y + particle.velocity.y
 			--if storage.player_looking_at_cerys then
-				r.target = {type = "position", position = p} --Render particle only if players are looking at Cerys. This saves a lot of performance when not looking at Cerys without changing any gameplay mechanics
+				particle.rendering.target = {type = "position", position = particle.position} --Render particle only if players are looking at Cerys. This saves a lot of performance when not looking at Cerys without changing any gameplay mechanics
 			--end
 			
 			--particle.age = particle.age + 1 --Now achieved via tracking the birth tick of new solar wind

--- a/scripts/atmosphere.lua
+++ b/scripts/atmosphere.lua
@@ -422,7 +422,10 @@ function Public.tick_8_solar_wind_collisions(probability_multiplier)
 					surface_cache[s_idx] = surface
 				end
 			end
+			if math.sqrt(particle.position.x^2+particle.position.y^2) > common.CERYS_RADIUS then goto continue end --Skip collision checks if particle is out of bounds of Cerys
+			
 			if surface then
+			local count =  surface.count_entities_filtered
 				local chars =
 					surface.find_entities_filtered({ name = "character", position = particle.position, radius = 1.2 })
 				if #chars > 0 then
@@ -474,15 +477,16 @@ function Public.tick_8_solar_wind_collisions(probability_multiplier)
 						end
 					end
 				end
-
-				local containers = surface.find_entities_filtered({
+				local container_filter = {
 					type = { "container", "logistic-container" },
 					position = particle.position,
 					-- has_item_inside = "uranium-238", -- this would only catch normal quality
 					radius = 0.75,
-				})
+				}
+				
 
-				if #containers > 0 then
+				if surface.count_entities_filtered(container_filter) > 0 then
+					local containers = surface.find_entities_filtered(container_filter)
 					local e = containers[1]
 					if e and e.valid then
 						local check = not (particle.last_checked_inv and particle.last_checked_inv == e.unit_number)
@@ -507,12 +511,13 @@ function Public.tick_8_solar_wind_collisions(probability_multiplier)
 
 				-- Note: Uranium on belts is more susceptible to slower wind. This is acceptable for now on a flavor basis of neutron capture.
 				if CHANCE_CHECK_BELT >= 1 or (math.random() < CHANCE_CHECK_BELT) then
-					local belts = surface.find_entities_filtered({
-						type = "transport-belt",
-						position = particle.position,
-						radius = 0.5,
-					})
-					if #belts > 0 then
+					local belt_filter = {
+							type = "transport-belt",
+							position = particle.position,
+							radius = 0.5,
+						}
+					if surface.count_entities_filtered(belt_filter) > 0 then
+						local belts = surface.find_entities_filtered(belt_filter)
 						local e = belts[1]
 						if e and e.valid then
 							local lines = {
@@ -575,6 +580,7 @@ function Public.tick_8_solar_wind_collisions(probability_multiplier)
 					end
 				end
 			end
+			::continue::
 		end
 	end
 end

--- a/scripts/background.lua
+++ b/scripts/background.lua
@@ -6,6 +6,8 @@ local Public = {}
 local PLANET_OFFSET = { x = 50, y = -30 }
 local PLANET_PARALLAX = 0.35
 
+assert(helpers.is_valid_sprite_path("cerys-fulgora-background"),"Sprite path 'cerys-fulgora-background' is invalid.")
+
 function Public.tick_1_update_background_renderings(surface)
 	if game.is_multiplayer() and settings.global["cerys-disable-parallax-in-multiplayer"].value then
 		if not storage.parallax_disabled then
@@ -25,7 +27,7 @@ function Public.tick_1_update_background_renderings(surface)
 			local on_cerys = player.surface.name == "cerys"
 			local r = storage.background_renderings[player.index]
 
-			if on_cerys and helpers.is_valid_sprite_path("cerys-fulgora-background") then
+			if on_cerys then
 				local stretch = lib.get_cerys_surface_stretch_factor(surface)
 				local planet_stretch = stretch
 				local extra_y_offset = -5 * (stretch - 1)

--- a/scripts/events.lua
+++ b/scripts/events.lua
@@ -264,7 +264,7 @@ function Public.simulation_tick(tick, cerys_surface)
 	end
 
 	if tick % 240 == 0 then
-		atmosphere.tick_240_clean_up_cerys_solar_wind_particles(cerys_surface)
+		atmosphere.tick_240_clean_up_cerys_solar_wind_particles(cerys_surface,tick)
 	end
 end
 
@@ -300,7 +300,7 @@ function Public.cerys_tick(surface, tick)
 		if tick % (7 * solar_wind_tick_multiplier) == 0 then
 			local spawn_chance = 0.35 * settings.global["cerys-solar-wind-spawn-rate-percentage"].value / 100
 			if math.random() < spawn_chance then
-				atmosphere.spawn_solar_wind_particle(surface)
+				atmosphere.spawn_solar_wind_particle(surface,tick)
 			end
 		end
 	end

--- a/scripts/events.lua
+++ b/scripts/events.lua
@@ -340,7 +340,7 @@ function Public.cerys_tick(surface, tick)
 		cooling.tick_60_cool_boilers()
 	end
 
-	if (player_looking_at_surface or player_on_surface) and tick % ice.ICE_CHECK_INTERVAL == 0 then
+	if (player_looking_at_surface or player_on_surface) and (tick + 1) % ice.ICE_CHECK_INTERVAL == 0 then
 		ice.tick_ice(surface)
 	end
 

--- a/scripts/events.lua
+++ b/scripts/events.lua
@@ -134,6 +134,10 @@ script.on_event(defines.events.on_pre_build, function(event)
 	end
 end)
 
+script.on_event(defines.events.on_surface_deleted , function()
+	storage.surface_some_chunk_generated = nil
+end)
+
 script.on_event("bplib-overlaps", function(event)
 	for bp_index, entity in pairs(event.overlaps) do
 		if

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -168,6 +168,9 @@ function Public.ensure_top_level_storage()
 	if not storage.accrued_probability_units then
 		storage.accrued_probability_units = 0
 	end
+	if not storage.cached_scale_factor then
+		 storage.cached_scale_factor = {}
+	end
 end
 
 function Public.ensure_cerys_storage_and_tables()


### PR DESCRIPTION
This PR contains some performance improvements that cache some repetitive computation and information gathered from chunk checks done during a few on_tick events. I estimate this saves about 0.3 ms/tick every tick. 

**get_cerys_surface_stretch_factor()** 
This function returns the stretch factor of Cerys given Cerys' world generation settings. This function's value will only change if Cery's worldgen settings are changed, which only normally can be changed in the editor, so I've cached this value in storage to save time.

**generated_cerys_surface()**

Finding this function was particularly shocking. This function currently checks if part of Cerys surface has generated by checking individual chunks until it finds a generated chunk. Unless something deletes a surface, once part of Cerys has generated, these chunk checks should not be necessary to check if Cerys has generated, so I've cached this variable(surface_some_chunk_generated) in storage so that subsequent chunk checks can be skipped. This function was called twice in two separate functions, costing about 0.2 ms/tick in total. On deleting any surface, this cached value is deleted, so this chunk checking function will be run once again later before the value is cached again.
 
**cached_scale_factor**

I don't know how much this will save, but it couldn't hurt to include. The scale factor calculation for dying solar wind particles is now memoized to skip some computation for each solar wind particle.